### PR TITLE
Fixed 'model is null' client crash

### DIFF
--- a/src/main/java/dev/lopyluna/dndesires/DesiresClient.java
+++ b/src/main/java/dev/lopyluna/dndesires/DesiresClient.java
@@ -13,8 +13,9 @@ import static dev.lopyluna.dndesires.DnDesires.MOD_ID;
 public class DesiresClient {
 
     public DesiresClient(IEventBus modEventBus) {
+        DesiresPartialModels.init();
         IEventBus neoEventBus = NeoForge.EVENT_BUS;
-        modEventBus.addListener(DesiresClient::clientInit);
+        //modEventBus.addListener(DesiresClient::clientInit);
     }
 
     public static void clientInit(final FMLClientSetupEvent event) {


### PR DESCRIPTION
Fixed 'model is null' client crash in heavy modpacks caused by partial models initialization is too late

*testing, my first time using github pull request, sry if anything is wrong >m<