### PR TITLE
Added toggle to configs to change the behavior of the handheld saw

### DIFF
--- a/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
@@ -10,7 +10,8 @@ public class DServer extends ConfigBase {
     public final ConfigInt chanceForOreStone = i(25, 1, 100, "chanceForOreStone", Comments.chanceForOreStone);
     public final ConfigInt chanceForArtificialOreStone = i(5, 0, 100, "chanceForArtificialOreStone", Comments.chanceForArtificialOreStone);
     public final ConfigInt handheldSawAirEfficiencyMultiplier = i(4, 1, 8, "handheldSawAirUsageMultiplier", Comments.handheldSawAirUsageMultiplier);
-
+    public final ConfigBool handheldSawConsumesAirPerTreeBlock = b(false, "handheldSawConsumesAirPerTreeBlock", Comments.handheldSawConsumesAirPerTreeBlock);
+    
     public final DKinetics kinetics = nested(0, DKinetics::new, "Parameters and abilities of Create: Desires 2 Dream's kinetic mechanisms");
 
     @Override
@@ -22,5 +23,6 @@ public class DServer extends ConfigBase {
         static String chanceForOreStone = "Chance for and Ore Stone to spawn when on top of Bedrock while Milkshake Stone Generating";
         static String chanceForArtificialOreStone = "Chance for and Ore Stone to spawn when on top of Artificial Bedrock while Milkshake Stone Generating";
         static String handheldSawAirEfficiencyMultiplier = "Multiplier for how many uses the Handheld Saw gets from a Backtank. Higher values reduce air usage, but air cost cannot go below 1 per use.";
+        static String handheldSawConsumesAirPerTreeBlock = "Should the Handheld Saw use more than the initial braking"
     }
 }

--- a/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
@@ -10,7 +10,7 @@ public class DServer extends ConfigBase {
     public final ConfigInt chanceForOreStone = i(25, 1, 100, "chanceForOreStone", Comments.chanceForOreStone);
     public final ConfigInt chanceForArtificialOreStone = i(5, 0, 100, "chanceForArtificialOreStone", Comments.chanceForArtificialOreStone);
     public final ConfigInt handheldSawAirEfficiencyMultiplier = i(4, 1, 8, "handheldSawAirEfficiencyMultiplier", Comments.handheldSawAirEfficiencyMultiplier);
-    public final ConfigBool handheldSawConsumesAirPerTreeBlock = b(false, "handheldSawConsumesAirPerTreeBlock", Comments.handheldSawConsumesAirPerTreeBlock);
+    public final ConfigBool handheldSawConsumesAirPerTreeBlock = b(true, "handheldSawConsumesAirPerTreeBlock", Comments.handheldSawConsumesAirPerTreeBlock);
     
     public final DKinetics kinetics = nested(0, DKinetics::new, "Parameters and abilities of Create: Desires 2 Dream's kinetic mechanisms");
 

--- a/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
@@ -26,6 +26,5 @@ public class DServer extends ConfigBase {
         static String handheldSawAirEfficiencyMultiplier = "Multiplier for how many uses the Handheld Saw gets from a Backtank. Higher values reduce air usage, but air cost cannot go below 1 per use.";
         static String handheldSawConsumesAirPerTreeBlock = "If enabled, the Handheld Saw can consume air for blocks broken during automatic tree cutting. If disabled, only the first manually broken block consumes air.";
         static String handheldSawOnlyLogsConsumeAirWhenDeforesting = "If enabled, only logs and roots consume air during automatic tree cutting. Leaves, vines, and other tree attachments will not consume air. If disabled, every automatically broken tree block can consume air.";
-);
     }
 }

--- a/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
@@ -9,7 +9,7 @@ public class DServer extends ConfigBase {
             "server", "Configs for the World");
     public final ConfigInt chanceForOreStone = i(25, 1, 100, "chanceForOreStone", Comments.chanceForOreStone);
     public final ConfigInt chanceForArtificialOreStone = i(5, 0, 100, "chanceForArtificialOreStone", Comments.chanceForArtificialOreStone);
-
+    public final ConfigInt handheldSawAirUsageMultiplier = i(4, 1, 64, "handheldSawAirUsageMultiplier", Comments.handheldSawAirUsageMultiplier);
 
     public final DKinetics kinetics = nested(0, DKinetics::new, "Parameters and abilities of Create: Desires 2 Dream's kinetic mechanisms");
 
@@ -21,5 +21,6 @@ public class DServer extends ConfigBase {
     private static class Comments {
         static String chanceForOreStone = "Chance for and Ore Stone to spawn when on top of Bedrock while Milkshake Stone Generating";
         static String chanceForArtificialOreStone = "Chance for and Ore Stone to spawn when on top of Artificial Bedrock while Milkshake Stone Generating";
+        static String handheldSawAirUsageMultiplier = "Multiplier for how many uses the Handheld Saw gets from a Backtank. Higher values make the saw consume less air. Default 4 makes it usually consume 1 air per use";
     }
 }

--- a/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
@@ -11,6 +11,7 @@ public class DServer extends ConfigBase {
     public final ConfigInt chanceForArtificialOreStone = i(5, 0, 100, "chanceForArtificialOreStone", Comments.chanceForArtificialOreStone);
     public final ConfigInt handheldSawAirEfficiencyMultiplier = i(4, 1, 8, "handheldSawAirEfficiencyMultiplier", Comments.handheldSawAirEfficiencyMultiplier);
     public final ConfigBool handheldSawConsumesAirPerTreeBlock = b(true, "handheldSawConsumesAirPerTreeBlock", Comments.handheldSawConsumesAirPerTreeBlock);
+    public final ConfigBool handheldSawOnlyLogsConsumeAirWhenDeforesting = b(true, "handheldSawOnlyLogsConsumeAirWhenDeforesting", Comments.handheldSawOnlyLogsConsumeAirWhenDeforesting);
     
     public final DKinetics kinetics = nested(0, DKinetics::new, "Parameters and abilities of Create: Desires 2 Dream's kinetic mechanisms");
 
@@ -23,6 +24,8 @@ public class DServer extends ConfigBase {
         static String chanceForOreStone = "Chance for and Ore Stone to spawn when on top of Bedrock while Milkshake Stone Generating";
         static String chanceForArtificialOreStone = "Chance for and Ore Stone to spawn when on top of Artificial Bedrock while Milkshake Stone Generating";
         static String handheldSawAirEfficiencyMultiplier = "Multiplier for how many uses the Handheld Saw gets from a Backtank. Higher values reduce air usage, but air cost cannot go below 1 per use.";
-        static String handheldSawConsumesAirPerTreeBlock = "If enabled, the Handheld Saw consumes air for every block broken during automatic tree cutting. If disabled, it only consumes air for the first manually broken block.";
+        static String handheldSawConsumesAirPerTreeBlock = "If enabled, the Handheld Saw can consume air for blocks broken during automatic tree cutting. If disabled, only the first manually broken block consumes air.";
+        static String handheldSawOnlyLogsConsumeAirWhenDeforesting = "If enabled, only logs and roots consume air during automatic tree cutting. Leaves, vines, and other tree attachments will not consume air. If disabled, every automatically broken tree block can consume air.";
+);
     }
 }

--- a/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
@@ -23,6 +23,6 @@ public class DServer extends ConfigBase {
         static String chanceForOreStone = "Chance for and Ore Stone to spawn when on top of Bedrock while Milkshake Stone Generating";
         static String chanceForArtificialOreStone = "Chance for and Ore Stone to spawn when on top of Artificial Bedrock while Milkshake Stone Generating";
         static String handheldSawAirEfficiencyMultiplier = "Multiplier for how many uses the Handheld Saw gets from a Backtank. Higher values reduce air usage, but air cost cannot go below 1 per use.";
-        static String handheldSawConsumesAirPerTreeBlock = "Should the Handheld Saw use more than the initial braking"
+        static String handheldSawConsumesAirPerTreeBlock = "If enabled, the Handheld Saw consumes air for every block broken during automatic tree cutting. If disabled, it only consumes air for the first manually broken block.";
     }
 }

--- a/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
@@ -9,7 +9,7 @@ public class DServer extends ConfigBase {
             "server", "Configs for the World");
     public final ConfigInt chanceForOreStone = i(25, 1, 100, "chanceForOreStone", Comments.chanceForOreStone);
     public final ConfigInt chanceForArtificialOreStone = i(5, 0, 100, "chanceForArtificialOreStone", Comments.chanceForArtificialOreStone);
-    public final ConfigInt handheldSawAirUsageMultiplier = i(4, 1, 64, "handheldSawAirUsageMultiplier", Comments.handheldSawAirUsageMultiplier);
+    public final ConfigInt handheldSawAirEfficiencyMultiplier = i(4, 1, 8, "handheldSawAirUsageMultiplier", Comments.handheldSawAirUsageMultiplier);
 
     public final DKinetics kinetics = nested(0, DKinetics::new, "Parameters and abilities of Create: Desires 2 Dream's kinetic mechanisms");
 
@@ -21,6 +21,6 @@ public class DServer extends ConfigBase {
     private static class Comments {
         static String chanceForOreStone = "Chance for and Ore Stone to spawn when on top of Bedrock while Milkshake Stone Generating";
         static String chanceForArtificialOreStone = "Chance for and Ore Stone to spawn when on top of Artificial Bedrock while Milkshake Stone Generating";
-        static String handheldSawAirUsageMultiplier = "Multiplier for how many uses the Handheld Saw gets from a Backtank. Higher values make the saw consume less air. Default 4 makes it usually consume 1 air per use";
+        static String handheldSawAirEfficiencyMultiplier = "Multiplier for how many uses the Handheld Saw gets from a Backtank. Higher values reduce air usage, but air cost cannot go below 1 per use.";
     }
 }

--- a/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/configs/DServer.java
@@ -9,7 +9,7 @@ public class DServer extends ConfigBase {
             "server", "Configs for the World");
     public final ConfigInt chanceForOreStone = i(25, 1, 100, "chanceForOreStone", Comments.chanceForOreStone);
     public final ConfigInt chanceForArtificialOreStone = i(5, 0, 100, "chanceForArtificialOreStone", Comments.chanceForArtificialOreStone);
-    public final ConfigInt handheldSawAirEfficiencyMultiplier = i(4, 1, 8, "handheldSawAirUsageMultiplier", Comments.handheldSawAirUsageMultiplier);
+    public final ConfigInt handheldSawAirEfficiencyMultiplier = i(4, 1, 8, "handheldSawAirEfficiencyMultiplier", Comments.handheldSawAirEfficiencyMultiplier);
     public final ConfigBool handheldSawConsumesAirPerTreeBlock = b(false, "handheldSawConsumesAirPerTreeBlock", Comments.handheldSawConsumesAirPerTreeBlock);
     
     public final DKinetics kinetics = nested(0, DKinetics::new, "Parameters and abilities of Create: Desires 2 Dream's kinetic mechanisms");

--- a/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
@@ -116,8 +116,8 @@ public class HandheldSawItem extends AxeItem implements CustomArmPoseItem, IOnBl
 
         // Do not consume extra air for blocks broken by the automatic tree-cutting chain.
         // The first manually broken block already paid the air cost.
-            if (deforesting)
-                return true;
+            if (deforesting && !DesiresConfigs.server().handheldSawConsumesAirPerTreeBlock.get())
+            return true;
 
             if (!BacktankUtil.canAbsorbDamage(miningEntity, maxUses())
                 && !level.isClientSide

--- a/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
@@ -112,10 +112,15 @@ public class HandheldSawItem extends AxeItem implements CustomArmPoseItem, IOnBl
     public boolean mineBlock(ItemStack stack, Level level, BlockState state, BlockPos pos, LivingEntity miningEntity) {
         var tool = stack.get(DataComponents.TOOL);
         if (tool != null) {
+            if (deforesting
+                // Check if the saw is only cutting tree logs and roots, and not count vines, etc.    
+                && !TreeCutter.isLog(state)
+                && !TreeCutter.isRoot(state)
 
-        // Do not consume extra air for blocks broken by the automatic tree-cutting chain.
-        // The first manually broken block already paid the air cost.
-            if (deforesting && !DesiresConfigs.server().handheldSawConsumesAirPerTreeBlock.get()) {
+                // If Enabled in the config do not consume extra air for blocks broken by the automatic tree-cutting chain.
+                // The first manually broken block already paid the air cost.
+
+                && !DesiresConfigs.server().handheldSawConsumesAirPerTreeBlock.get()) {
                 return true;
             }
 

--- a/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
@@ -9,7 +9,7 @@ import dev.lopyluna.dndesires.content.items.IOnBlockBreak;
 import dev.lopyluna.dndesires.content.items.TreeOverride;
 import dev.lopyluna.dndesires.mixins.AxeItemAccessor;
 import dev.lopyluna.dndesires.register.DesiresItems;
-import dev.lopyluna.dndesires.register.DesiresConfigs
+import dev.lopyluna.dndesires.register.DesiresConfigs;
 import net.createmod.catnip.math.VecHelper;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.client.model.HumanoidModel;

--- a/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
@@ -108,32 +108,53 @@ public class HandheldSawItem extends AxeItem implements CustomArmPoseItem, IOnBl
 //      }
 //      return false;
 //  }
-    @Override
-    public boolean mineBlock(ItemStack stack, Level level, BlockState state, BlockPos pos, LivingEntity miningEntity) {
-        var tool = stack.get(DataComponents.TOOL);
-        if (tool != null) {
-            if (deforesting
-                // Check if the saw is only cutting tree logs and roots, and not count vines, etc.    
-                && !TreeCutter.isLog(state)
-                && !TreeCutter.isRoot(state)
+@Override
+public boolean mineBlock(ItemStack stack, Level level, BlockState state, BlockPos pos, LivingEntity miningEntity) {
+    var tool = stack.get(DataComponents.TOOL);
+    if (tool != null) {
 
-                // If Enabled in the config do not consume extra air for blocks broken by the automatic tree-cutting chain.
-                // The first manually broken block already paid the air cost.
-
-                && !DesiresConfigs.server().handheldSawConsumesAirPerTreeBlock.get()) {
-                return true;
-            }
-
-            if (!BacktankUtil.canAbsorbDamage(miningEntity, maxUses())
-                && !level.isClientSide
-                && state.getDestroySpeed(level, pos) != 0.0F
-                && tool.damagePerBlock() > 0) {
-                stack.hurtAndBreak(tool.damagePerBlock(), miningEntity, EquipmentSlot.MAINHAND);
-            }
+        // Do not consume extra air for blocks broken by the automatic tree-cutting chain.
+        // The first manually broken block already paid the air cost.
+        if (deforesting && !DesiresConfigs.server().handheldSawConsumesAirPerTreeBlock.get()) {
             return true;
         }
-        return false;
+
+        var backtanksBeforeUse = BacktankUtil.getAllWithAir(miningEntity);
+        ItemStack usedBacktank = backtanksBeforeUse.isEmpty() ? ItemStack.EMPTY : backtanksBeforeUse.getFirst();
+        int airBefore = usedBacktank.isEmpty() ? 0 : BacktankUtil.getAir(usedBacktank);
+        int maxAir = usedBacktank.isEmpty() ? BacktankUtil.maxAirWithoutEnchants() : BacktankUtil.maxAir(usedBacktank);
+
+        boolean absorbedWithAir = BacktankUtil.canAbsorbDamage(miningEntity, maxUses());
+
+        if (!level.isClientSide && miningEntity instanceof Player player) {
+            if (!usedBacktank.isEmpty()) {
+                int airAfter = BacktankUtil.getAir(usedBacktank);
+                int airUsed = airBefore - airAfter;
+
+                player.displayClientMessage(
+                    Component.literal("Handheld Saw air: " + airAfter + "/" + maxAir + " used: " + airUsed),
+                    true
+                );
+            } else {
+                player.displayClientMessage(
+                    Component.literal("Handheld Saw air: no backtank air found"),
+                    true
+                );
+            }
+        }
+
+        if (!absorbedWithAir
+            && !level.isClientSide
+            && state.getDestroySpeed(level, pos) != 0.0F
+            && tool.damagePerBlock() > 0) {
+            stack.hurtAndBreak(tool.damagePerBlock(), miningEntity, EquipmentSlot.MAINHAND);
+        }
+
+        return true;
     }
+
+    return false;
+}
 
     @Override
     public boolean canAttackBlock(BlockState state, Level level, BlockPos pos, Player player) {

--- a/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
@@ -9,6 +9,7 @@ import dev.lopyluna.dndesires.content.items.IOnBlockBreak;
 import dev.lopyluna.dndesires.content.items.TreeOverride;
 import dev.lopyluna.dndesires.mixins.AxeItemAccessor;
 import dev.lopyluna.dndesires.register.DesiresItems;
+import dev.lopyluna.dndesires.register.DesiresConfigs
 import net.createmod.catnip.math.VecHelper;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.client.model.HumanoidModel;

--- a/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
@@ -16,6 +16,7 @@ import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;

--- a/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
@@ -97,16 +97,40 @@ public class HandheldSawItem extends AxeItem implements CustomArmPoseItem, IOnBl
         if (!BacktankUtil.canAbsorbDamage(attacker, maxUses())) stack.hurtAndBreak(2, attacker, EquipmentSlot.MAINHAND);
     }
 
+    //Original:
+//  @Override
+//  public boolean mineBlock(ItemStack stack, Level level, BlockState state, BlockPos pos, LivingEntity miningEntity) {
+//      var tool = stack.get(DataComponents.TOOL);
+//        if (tool != null) {
+//          if (!BacktankUtil.canAbsorbDamage(miningEntity, maxUses()) && !level.isClientSide && state.getDestroySpeed(level, pos) != 0.0F && tool.damagePerBlock() > 0)
+//              stack.hurtAndBreak(tool.damagePerBlock(), miningEntity, EquipmentSlot.MAINHAND);
+//          return true;
+//      }
+//      return false;
+//  }
+
     @Override
     public boolean mineBlock(ItemStack stack, Level level, BlockState state, BlockPos pos, LivingEntity miningEntity) {
         var tool = stack.get(DataComponents.TOOL);
         if (tool != null) {
-            if (!BacktankUtil.canAbsorbDamage(miningEntity, maxUses()) && !level.isClientSide && state.getDestroySpeed(level, pos) != 0.0F && tool.damagePerBlock() > 0)
+
+        // Do not consume extra air for blocks broken by the automatic tree-cutting chain.
+        // The first manually broken block already paid the air cost.
+            if (deforesting)
+                return true;
+
+            if (!BacktankUtil.canAbsorbDamage(miningEntity, maxUses())
+                && !level.isClientSide
+                && state.getDestroySpeed(level, pos) != 0.0F
+                && tool.damagePerBlock() > 0) {
                 stack.hurtAndBreak(tool.damagePerBlock(), miningEntity, EquipmentSlot.MAINHAND);
+            }
             return true;
         }
         return false;
     }
+
+
 
     @Override
     public boolean canAttackBlock(BlockState state, Level level, BlockPos pos, Player player) {
@@ -140,7 +164,7 @@ public class HandheldSawItem extends AxeItem implements CustomArmPoseItem, IOnBl
         // return AllConfigs.server().equipment.maxPotatoCannonShots.get() * 4;
         
         int baseUses = AllConfigs.server().equipment.maxPotatoCannonShots.get();
-        int multiplier = DesiresConfigs.server().handheldSawAirUsageMultiplier.get();
+        int multiplier = DesiresConfigs.server().handheldSawAirEfficiencyMultiplier.get();
 
         return baseUses * multiplier;
     }

--- a/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
@@ -135,7 +135,13 @@ public class HandheldSawItem extends AxeItem implements CustomArmPoseItem, IOnBl
     private static int maxUses() {
         // Original = airInBacktank = 900 / maxPotatoCannonShots = 200
         // return AllConfigs.server().equipment.maxPotatoCannonShots.get();
-        return AllConfigs.server().equipment.maxPotatoCannonShots.get() * 4;
+        // New own made (not tested, 1 Air usage instead of 4
+        // return AllConfigs.server().equipment.maxPotatoCannonShots.get() * 4;
+        
+        int baseUses = AllConfigs.server().equipment.maxPotatoCannonShots.get();
+        int multiplier = DesiresConfigs.server().handheldSawAirUsageMultiplier.get();
+
+        return baseUses * multiplier;
     }
 
     @Override

--- a/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
@@ -16,7 +16,6 @@ import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -101,64 +100,29 @@ public class HandheldSawItem extends AxeItem implements CustomArmPoseItem, IOnBl
     @Override
     public boolean mineBlock(ItemStack stack, Level level, BlockState state, BlockPos pos, LivingEntity miningEntity) {
         var tool = stack.get(DataComponents.TOOL);
-        if (tool != null) {
+        if (tool == null)
+            return false;
 
-            if (deforesting) {
+        if (deforesting) {
+            if (!DesiresConfigs.server().handheldSawConsumesAirPerTreeBlock.get())
+                return true;
 
-            // Only the first manually broken block consumes air.
-                if (!DesiresConfigs.server().handheldSawConsumesAirPerTreeBlock.get()) {
-                    return true;
-                }
-
-            // During automatic tree cutting, consume air for logs/roots only.
-            // Leaves, vines, cocoa, bee nests, etc. are skipped.
-                if (DesiresConfigs.server().handheldSawOnlyLogsConsumeAirWhenDeforesting.get()
-                    && !TreeCutter.isLog(state)
-                    && !TreeCutter.isRoot(state)) {
-                    return true;
-                }
-            }
-
-            var backtanksBeforeUse = BacktankUtil.getAllWithAir(miningEntity);
-            ItemStack usedBacktank = backtanksBeforeUse.isEmpty() ? ItemStack.EMPTY : backtanksBeforeUse.getFirst();
-            int airBefore = usedBacktank.isEmpty() ? 0 : BacktankUtil.getAir(usedBacktank);
-            int maxAir = usedBacktank.isEmpty() ? BacktankUtil.maxAirWithoutEnchants() : BacktankUtil.maxAir(usedBacktank);
-
-            boolean absorbedWithAir = BacktankUtil.canAbsorbDamage(miningEntity, maxUses());
-
-            if (!level.isClientSide && miningEntity instanceof Player player) {
-                if (!usedBacktank.isEmpty()) {
-                    int airAfter = BacktankUtil.getAir(usedBacktank);
-                    int airUsed = airBefore - airAfter;
-
-                    player.displayClientMessage(
-                        Component.literal(
-                            "Saw air: " + airAfter + "/" + maxAir +
-                            " used: " + airUsed +
-                            " block: " + state.getBlock().getName().getString() +
-                            " deforesting: " + deforesting
-                        ),
-                        true
-                    );
-                } else {
-                    player.displayClientMessage(
-                        Component.literal("Saw air: no backtank air found"),
-                        true
-                    );
-                }
-            }
-
-            if (!absorbedWithAir
-                && !level.isClientSide
-                && state.getDestroySpeed(level, pos) != 0.0F
-                && tool.damagePerBlock() > 0) {
-                stack.hurtAndBreak(tool.damagePerBlock(), miningEntity, EquipmentSlot.MAINHAND);
-            }
-
-            return true;
+            if (DesiresConfigs.server().handheldSawOnlyLogsConsumeAirWhenDeforesting.get()
+                && !TreeCutter.isLog(state)
+                && !TreeCutter.isRoot(state))
+                return true;
         }
 
-        return false;
+        boolean absorbedWithAir = BacktankUtil.canAbsorbDamage(miningEntity, maxUses());
+
+        if (!absorbedWithAir
+            && !level.isClientSide
+            && state.getDestroySpeed(level, pos) != 0.0F
+            && tool.damagePerBlock() > 0) {
+            stack.hurtAndBreak(tool.damagePerBlock(), miningEntity, EquipmentSlot.MAINHAND);
+        }
+
+        return true;
     }
 
     @Override

--- a/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
@@ -98,64 +98,68 @@ public class HandheldSawItem extends AxeItem implements CustomArmPoseItem, IOnBl
         if (!BacktankUtil.canAbsorbDamage(attacker, maxUses())) stack.hurtAndBreak(2, attacker, EquipmentSlot.MAINHAND);
     }
 
-    //Original:
-//  @Override
-//  public boolean mineBlock(ItemStack stack, Level level, BlockState state, BlockPos pos, LivingEntity miningEntity) {
-//      var tool = stack.get(DataComponents.TOOL);
-//        if (tool != null) {
-//          if (!BacktankUtil.canAbsorbDamage(miningEntity, maxUses()) && !level.isClientSide && state.getDestroySpeed(level, pos) != 0.0F && tool.damagePerBlock() > 0)
-//              stack.hurtAndBreak(tool.damagePerBlock(), miningEntity, EquipmentSlot.MAINHAND);
-//          return true;
-//      }
-//      return false;
-//  }
-@Override
-public boolean mineBlock(ItemStack stack, Level level, BlockState state, BlockPos pos, LivingEntity miningEntity) {
-    var tool = stack.get(DataComponents.TOOL);
-    if (tool != null) {
+    @Override
+    public boolean mineBlock(ItemStack stack, Level level, BlockState state, BlockPos pos, LivingEntity miningEntity) {
+        var tool = stack.get(DataComponents.TOOL);
+        if (tool != null) {
 
-        // Do not consume extra air for blocks broken by the automatic tree-cutting chain.
-        // The first manually broken block already paid the air cost.
-        if (deforesting && !DesiresConfigs.server().handheldSawConsumesAirPerTreeBlock.get()) {
+            if (deforesting) {
+
+            // Only the first manually broken block consumes air.
+                if (!DesiresConfigs.server().handheldSawConsumesAirPerTreeBlock.get()) {
+                    return true;
+                }
+
+            // During automatic tree cutting, consume air for logs/roots only.
+            // Leaves, vines, cocoa, bee nests, etc. are skipped.
+                if (DesiresConfigs.server().handheldSawOnlyLogsConsumeAirWhenDeforesting.get()
+                    && !TreeCutter.isLog(state)
+                    && !TreeCutter.isRoot(state)) {
+                    return true;
+                }
+            }
+
+            var backtanksBeforeUse = BacktankUtil.getAllWithAir(miningEntity);
+            ItemStack usedBacktank = backtanksBeforeUse.isEmpty() ? ItemStack.EMPTY : backtanksBeforeUse.getFirst();
+            int airBefore = usedBacktank.isEmpty() ? 0 : BacktankUtil.getAir(usedBacktank);
+            int maxAir = usedBacktank.isEmpty() ? BacktankUtil.maxAirWithoutEnchants() : BacktankUtil.maxAir(usedBacktank);
+
+            boolean absorbedWithAir = BacktankUtil.canAbsorbDamage(miningEntity, maxUses());
+
+            if (!level.isClientSide && miningEntity instanceof Player player) {
+                if (!usedBacktank.isEmpty()) {
+                    int airAfter = BacktankUtil.getAir(usedBacktank);
+                    int airUsed = airBefore - airAfter;
+
+                    player.displayClientMessage(
+                        Component.literal(
+                            "Saw air: " + airAfter + "/" + maxAir +
+                            " used: " + airUsed +
+                            " block: " + state.getBlock().getName().getString() +
+                            " deforesting: " + deforesting
+                        ),
+                        true
+                    );
+                } else {
+                    player.displayClientMessage(
+                        Component.literal("Saw air: no backtank air found"),
+                        true
+                    );
+                }
+            }
+
+            if (!absorbedWithAir
+                && !level.isClientSide
+                && state.getDestroySpeed(level, pos) != 0.0F
+                && tool.damagePerBlock() > 0) {
+                stack.hurtAndBreak(tool.damagePerBlock(), miningEntity, EquipmentSlot.MAINHAND);
+            }
+
             return true;
         }
 
-        var backtanksBeforeUse = BacktankUtil.getAllWithAir(miningEntity);
-        ItemStack usedBacktank = backtanksBeforeUse.isEmpty() ? ItemStack.EMPTY : backtanksBeforeUse.getFirst();
-        int airBefore = usedBacktank.isEmpty() ? 0 : BacktankUtil.getAir(usedBacktank);
-        int maxAir = usedBacktank.isEmpty() ? BacktankUtil.maxAirWithoutEnchants() : BacktankUtil.maxAir(usedBacktank);
-
-        boolean absorbedWithAir = BacktankUtil.canAbsorbDamage(miningEntity, maxUses());
-
-        if (!level.isClientSide && miningEntity instanceof Player player) {
-            if (!usedBacktank.isEmpty()) {
-                int airAfter = BacktankUtil.getAir(usedBacktank);
-                int airUsed = airBefore - airAfter;
-
-                player.displayClientMessage(
-                    Component.literal("Handheld Saw air: " + airAfter + "/" + maxAir + " used: " + airUsed),
-                    true
-                );
-            } else {
-                player.displayClientMessage(
-                    Component.literal("Handheld Saw air: no backtank air found"),
-                    true
-                );
-            }
-        }
-
-        if (!absorbedWithAir
-            && !level.isClientSide
-            && state.getDestroySpeed(level, pos) != 0.0F
-            && tool.damagePerBlock() > 0) {
-            stack.hurtAndBreak(tool.damagePerBlock(), miningEntity, EquipmentSlot.MAINHAND);
-        }
-
-        return true;
+        return false;
     }
-
-    return false;
-}
 
     @Override
     public boolean canAttackBlock(BlockState state, Level level, BlockPos pos, Player player) {

--- a/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
@@ -108,7 +108,6 @@ public class HandheldSawItem extends AxeItem implements CustomArmPoseItem, IOnBl
 //      }
 //      return false;
 //  }
-
     @Override
     public boolean mineBlock(ItemStack stack, Level level, BlockState state, BlockPos pos, LivingEntity miningEntity) {
         var tool = stack.get(DataComponents.TOOL);
@@ -116,8 +115,9 @@ public class HandheldSawItem extends AxeItem implements CustomArmPoseItem, IOnBl
 
         // Do not consume extra air for blocks broken by the automatic tree-cutting chain.
         // The first manually broken block already paid the air cost.
-            if (deforesting && !DesiresConfigs.server().handheldSawConsumesAirPerTreeBlock.get())
-            return true;
+            if (deforesting && !DesiresConfigs.server().handheldSawConsumesAirPerTreeBlock.get()) {
+                return true;
+            }
 
             if (!BacktankUtil.canAbsorbDamage(miningEntity, maxUses())
                 && !level.isClientSide
@@ -129,8 +129,6 @@ public class HandheldSawItem extends AxeItem implements CustomArmPoseItem, IOnBl
         }
         return false;
     }
-
-
 
     @Override
     public boolean canAttackBlock(BlockState state, Level level, BlockPos pos, Player player) {

--- a/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
+++ b/src/main/java/dev/lopyluna/dndesires/content/items/handheld_saw/HandheldSawItem.java
@@ -133,7 +133,9 @@ public class HandheldSawItem extends AxeItem implements CustomArmPoseItem, IOnBl
     }
 
     private static int maxUses() {
-        return AllConfigs.server().equipment.maxPotatoCannonShots.get();
+        // Original = airInBacktank = 900 / maxPotatoCannonShots = 200
+        // return AllConfigs.server().equipment.maxPotatoCannonShots.get();
+        return AllConfigs.server().equipment.maxPotatoCannonShots.get() * 4;
     }
 
     @Override


### PR DESCRIPTION
Handheld Saw consumes a lot of backtank air when cutting certain types of trees like jungle trees.

This happens because the code checks for leaves and other "accessories" that a tree has. Some trees like Jungle trees have vines (really long ones on chunks that have been simulated for awhile) effectively emptying the basic backtank on one go.

The basic efficiency seems to be alright when the cutting doesn't count the leaves and vines.

This will generate:
- A config toggle, to leave the calculation as is, or to ignore leaves and other accessories. 
- A toggle for consuming air for only one block even if the tree is deforrested. 
- Effiency calculation tweaks

Default with this code is that the effiency is kept as is. And the consumed air is all the logs, but not leafs.